### PR TITLE
Added a new load function.

### DIFF
--- a/Assets/Javascript/script.js
+++ b/Assets/Javascript/script.js
@@ -1,4 +1,6 @@
 $(document).ready(function () {
+    load();
+
     var userInput;
 
     $('.button').click(clickSearch)
@@ -20,6 +22,64 @@ $(document).ready(function () {
                 search();
             }
         }
+    }
+
+    function load() {
+        var date = new Date();
+        var year = date.getFullYear();
+
+        $.ajax({
+            url: `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=COVID19&fq=${year}&api-key=fba9vvYnRyI2O33HRL1AhwLy6ywpxVpH`,
+            method: 'GET'
+        }).then(function (nyResponse) {
+            console.log(nyResponse);
+
+            $('.articleSection').empty();
+
+            for (var i = 0; i < 3; i++) {
+                var div = $('<div>');
+              
+                if (nyResponse.response.docs[i].multimedia.length !== 0) {
+                    var img = $('<img>').attr('src', `https://www.nytimes.com/${nyResponse.response.docs[i].multimedia[19].url}`);
+                } else {
+                    var img = $('<img>').attr('src', 'https://i.pinimg.com/originals/c4/81/1d/c4811d59c17568b2ea75b1327d0dfc9e.jpg');
+                    img.css('width', '150px')
+                }
+
+                var articleLink = $('<a>');
+
+                var articleTitle = $('<h4 style="text-decoration: none; color: blue; font-size: medium">').text(nyResponse.response.docs[i].headline.main);
+                
+                articleLink.append(articleTitle).attr({'href': nyResponse.response.docs[i].web_url, 'target': '_blank'});
+
+                div.append(img, articleLink);
+
+                $('.articleSection').append(div);
+            }
+        })
+
+        var bloomSettings = {
+            "async": true,
+            "crossDomain": true,
+            "url": "https://bloomberg-market-and-financial-news.p.rapidapi.com/stories/list?template=CURRENCY&id=usdjpy",
+            "method": "GET",
+            "headers": {
+                "x-rapidapi-host": "bloomberg-market-and-financial-news.p.rapidapi.com",
+                "x-rapidapi-key": "7e99fbd181msh93eb9db94711373p1b2374jsn70b4f002fe55"
+            }
+        }
+    
+        // $.ajax(bloomSettings).then(function (bloomResponse) {
+        //     console.log(bloomResponse);
+    
+        //     for (var i = 0; i < 3; i++) {
+        //         $(`.finArt${i}`).text(bloomResponse.stories[i].title);
+        //         $(`.finArt${i}`).attr("href", bloomResponse.stories[i].shortURL);
+        //         $(`.finArt${i}Img`).attr("src", bloomResponse.stories[i].thumbnailImage)
+        //     }
+        // }).catch(function (error) {
+        //     console.log(error)
+        // });
     }
 
     function search() {
@@ -113,27 +173,6 @@ $(document).ready(function () {
             }
         })
     }
-
-    var bloomSettings = {
-        "async": true,
-        "crossDomain": true,
-        "url": "https://bloomberg-market-and-financial-news.p.rapidapi.com/stories/list?template=CURRENCY&id=usdjpy",
-        "method": "GET",
-        "headers": {
-            "x-rapidapi-host": "bloomberg-market-and-financial-news.p.rapidapi.com",
-            "x-rapidapi-key": "b2328dbcaamshe375150f85e5095p15818ejsnbf708ecc2a82"
-        }
-    }
-
-    $.ajax(bloomSettings).then(function (bloomResponse) {
-        console.log(bloomResponse);
-
-        for (var i = 0; i < 3; i++) {
-            $(`.finArt${i}`).text(bloomResponse.stories[i].title);
-            $(`.finArt${i}`).attr("href", bloomResponse.stories[i].shortURL);
-            $(`.finArt${i}Img`).attr("src", bloomResponse.stories[i].thumbnailImage)
-        }
-    });
 })
 
 


### PR DESCRIPTION
I also made it so that NY times articles will load with the function, and I fixed the Bloomberg API key, and commented out the Bloomberg ajax request so we don't go over our monthly limit easily.